### PR TITLE
fix: org create route

### DIFF
--- a/app/routers/org.py
+++ b/app/routers/org.py
@@ -55,6 +55,12 @@ def create(
             return porg
         except ValidationError as e:
             raise HTTPException(status_code=422, detail=e.errors())
+        except Exception as e:
+            if hasattr(e, "status_code") and e.status_code is not None:
+                detail = e.detail if hasattr(e, "detail") else e.message
+                raise HTTPException(status_code=e.status_code, detail=detail)
+
+            raise e
 
 
 @router.get("/{org_id}", response_model=Org, response_model_exclude_none=True)


### PR DESCRIPTION
org creation route can get error from hooks that it need to change to http exceptions. made a heuristic to catch all errors that have status_code and either "detail" or "message" and change them into http exceptions.