### PR TITLE
fix: provision webhook

### DIFF
--- a/app/llm/tools/provision/webhook.py
+++ b/app/llm/tools/provision/webhook.py
@@ -22,9 +22,8 @@ class WebhookImpl(ProvisionInterface):
             )
 
         body = {**kwargs, "requester_email": requester_email}
-        try:
-            response = requests.post(url=self.url, json=body)
-            return response.status_code >= 200 and response.status_code <= 399
-        except Exception:
-            # logger
-            return False
+        response = requests.post(url=self.url, json=body)
+        if response.status_code >= 200 and response.status_code <= 399:
+            return True
+        else:
+            raise ValueError(response.text)


### PR DESCRIPTION
webhook implementation should raise an error if request was unsuccessful instead of returning False