### PR TITLE
fix: sqlite retriever

### DIFF
--- a/app/auth.py
+++ b/app/auth.py
@@ -167,6 +167,8 @@ async def setup_workspace_vstore(
     ws: Annotated[Workspace, Depends(get_current_workspace)],
 ):
     wvstore = create_workspace_vstore(
-        ws.id, create_embedding(settings.VSTORE_EMBEDDING)
+        workspace_id=ws.id,
+        embedding=create_embedding(settings.VSTORE_EMBEDDING),
+        workspace_unique_name=ws.unique_name,
     )
     return wvstore

--- a/app/llm/agents.py
+++ b/app/llm/agents.py
@@ -8,7 +8,6 @@ from langchain.tools import Tool
 from langchain_core.runnables import RunnablePassthrough
 from langchain_core.utils.function_calling import convert_to_openai_function
 
-# from ..llm.tools.retriever_tool import create_retriever_tool
 from ..settings import settings
 from .model import create_model, get_model_from_uri
 from .prompts import MEMORY_KEY

--- a/app/llm/conversation.py
+++ b/app/llm/conversation.py
@@ -38,9 +38,12 @@ def create_agent_for_access_request_conversation(
     data_context: dict[str, Any],
     checkpointer: BaseCheckpointSaver = None,
 ):
+    workspace_unique_name = ws.unique_name if ws is not None else None
     embedding = create_embedding()
     retriever = create_retriever(
-        workspace_id=conversation.workspace_id, embedding=embedding
+        workspace_id=conversation.workspace_id,
+        embedding=embedding,
+        workspace_unique_name=workspace_unique_name,
     )
 
     if checkpointer is None:

--- a/app/tests/test_vector_store.py
+++ b/app/tests/test_vector_store.py
@@ -18,10 +18,12 @@ def setup_teardown(request):
 class TestVectorStore:
     def test_create_workspace_vstore(self):
         workspace_id = "acme"
+        workspace_unique_name = "acme"
         vs = create_workspace_vstore(
-            workspace_id,
+            workspace_id=workspace_id,
             uri=f"sqlite://{self.db_file}",
             embedding=create_embedding("sentence_transformer"),
+            workspace_unique_name=workspace_unique_name,
         )
         t1 = "Ketanji Brown Jackson is awesome"
         t2 = "Ketanji Brown Jackson job is a judge"


### PR DESCRIPTION
use workspace unique name for sqlite table names instead of workspace_id

closes #54 