### PR TITLE
fix: on topic guardrail

### DIFF
--- a/app/llm/guardrails/on_topic.py
+++ b/app/llm/guardrails/on_topic.py
@@ -37,13 +37,16 @@ def on_topic_guard():
         "action repetition request",
     ]
     template = """
-      Your job is to determine if the conversation is on topic. 
-      Any of the following topics are allowed, together or individually: 
+      You are a guardrail agent with the job of determining if the conversation is on topic.
+      The topic of the conversation is, generally, requesting and granting access.
+      Here are example allowed topics:
       {allowed_topics}
 
       The conversation is valid if the entire conversation is on topic or if the latest human message
       tries to bring it back on topic.
-
+      Be permissive in your judgment, but don't allow general information questions or nonsense messages.
+      Remember, there are other LLM agents that need to interact with the user after you.   
+      
       {format_instructions}
     """
     pv = {

--- a/app/llm/nodes.py
+++ b/app/llm/nodes.py
@@ -156,7 +156,7 @@ def entry_point_node(data_context):
         )
 
         corou = agent.ainvoke(state)
-        input = state[MEMORY_KEY][-5:]
+        input = state[MEMORY_KEY][-15:]
         result, ok = asyncio.new_event_loop().run_until_complete(
             execute_chat_with_guardrail(runnable=corou, input=input)
         )


### PR DESCRIPTION
rework the on topic guardrail.
make it consider the conversation in more general terms and provide examples instead of specific topics. 
Give it a larger context window to consider so the user won't get stuck on the guard.