### PR TITLE
fix: openai embedding model

### DIFF
--- a/app/embeddings.py
+++ b/app/embeddings.py
@@ -9,7 +9,7 @@ from .settings import settings
 
 def create_embedding(embedding_type: str = settings.VSTORE_EMBEDDING) -> Embeddings:
     if embedding_type == "openai":
-        return OpenAIEmbeddings()
+        return OpenAIEmbeddings(model="text-embedding-3-large")
     elif embedding_type == "sentence_transformer":
         return SentenceTransformerEmbeddings(model_name="all-MiniLM-L6-v2")
     else:


### PR DESCRIPTION
use the more recent openai's embedding model instead of the deprecated ada-002

IMPORTANT: requires re inserting any previously inserted data